### PR TITLE
chore: update AGENTS remote-branch guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,6 @@ All agents must follow these rules:
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
 4) PR descriptions must include Summary, Rationale, and Details sections.
-5) If the branch you're assigned to work on tracks a remote branch (e.g., origin/master or upstream/awesome-feature), you must sync it before you begin:
-   - `git fetch <remote>` and then `git pull --rebase` (or the repo's preferred update method).
-   - Confirm your local branch is at the latest remote HEAD.
+5) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,8 @@ All agents must follow these rules:
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
 4) PR descriptions must include Summary, Rationale, and Details sections.
+5) If the branch you're assigned to work on tracks a remote branch (e.g., origin/master or upstream/awesome-feature), you must sync it before you begin:
+   - `git fetch <remote>` and then `git pull --rebase` (or the repo's preferred update method).
+   - Confirm your local branch is at the latest remote HEAD.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add guidance in `AGENTS.md` to fetch and update a remote-tracking branch before starting work.

Rationale:
- Ensures changes begin from the latest remote state to avoid stale bases and conflicts.

Details:
- Document the remote-branch update step in `AGENTS.md`.